### PR TITLE
Support swift 2.*

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 0.5
+github "antitypical/Result" ~> 1.0.1

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 0.4
-github "Quick/Nimble" "v2.0.0-rc.1"
+github "Quick/Quick" ~> 0.8.0
+github "Quick/Nimble" ~> 3.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "dbc5bb3e2bd7e7ce322b128d674983937bbffd57"
-github "Quick/Quick" "v0.4.0"
-github "antitypical/Result" "0.5"
+github "Quick/Nimble" "v3.0.0"
+github "Quick/Quick" "v0.8.0"
+github "antitypical/Result" "1.0.1"

--- a/ValueTransformer/ReversibleValueTransformer.swift
+++ b/ValueTransformer/ReversibleValueTransformer.swift
@@ -2,7 +2,7 @@
 
 import Result
 
-public struct ReversibleValueTransformer<Value, TransformedValue, Error>: ReversibleValueTransformerType {
+public struct ReversibleValueTransformer<Value, TransformedValue, Error: ErrorType>: ReversibleValueTransformerType {
     private let transformClosure: Value -> Result<TransformedValue, Error>
     private let reverseTransformClosure: TransformedValue -> Result<Value, Error>
 
@@ -21,7 +21,7 @@ public struct ReversibleValueTransformer<Value, TransformedValue, Error>: Revers
 }
 
 extension ReversibleValueTransformer {
-    public init<V: ReversibleValueTransformerType where V.ValueType == Value, V.TransformedValueType == TransformedValue, V.ErrorType == Error>(_ reversibleValueTransformer: V) {
+    public init<V: ReversibleValueTransformerType where V.ValueType == Value, V.TransformedValueType == TransformedValue, V.VTErrorType == Error>(_ reversibleValueTransformer: V) {
         self.init(transformClosure: { value in
             return reversibleValueTransformer.transform(value)
         }, reverseTransformClosure: { transformedValue in
@@ -32,19 +32,19 @@ extension ReversibleValueTransformer {
 
 // MARK: - Combine
 
-public func combine<V: ValueTransformerType, W: ValueTransformerType where V.ValueType == W.TransformedValueType, V.TransformedValueType == W.ValueType, V.ErrorType == W.ErrorType>(valueTransformer: V, _ reverseValueTransformer: W) -> ReversibleValueTransformer<V.ValueType, V.TransformedValueType, V.ErrorType> {
+public func combine<V: ValueTransformerType, W: ValueTransformerType where V.ValueType == W.TransformedValueType, V.TransformedValueType == W.ValueType, V.VTErrorType == W.VTErrorType>(valueTransformer: V, _ reverseValueTransformer: W) -> ReversibleValueTransformer<V.ValueType, V.TransformedValueType, V.VTErrorType> {
     return ReversibleValueTransformer(transformClosure: transform(valueTransformer), reverseTransformClosure: transform(reverseValueTransformer))
 }
 
 // MARK: - Flip
 
-public func flip<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> ReversibleValueTransformer<V.TransformedValueType, V.ValueType, V.ErrorType> {
+public func flip<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> ReversibleValueTransformer<V.TransformedValueType, V.ValueType, V.VTErrorType> {
     return ReversibleValueTransformer(transformClosure: reverseTransform(reversibleValueTransformer), reverseTransformClosure: transform(reversibleValueTransformer))
 }
 
 // MARK: - Compose
 
-public func compose<V: ReversibleValueTransformerType, W: ReversibleValueTransformerType where V.TransformedValueType == W.ValueType, V.ErrorType == W.ErrorType>(left: V, _ right: W) -> ReversibleValueTransformer<V.ValueType, W.TransformedValueType, W.ErrorType> {
+public func compose<V: ReversibleValueTransformerType, W: ReversibleValueTransformerType where V.TransformedValueType == W.ValueType, V.VTErrorType == W.VTErrorType>(left: V, _ right: W) -> ReversibleValueTransformer<V.ValueType, W.TransformedValueType, W.VTErrorType> {
     return combine(left >>> right as ValueTransformer, flip(right) >>> flip(left) as ValueTransformer)
 }
 
@@ -53,7 +53,7 @@ infix operator >>> {
     precedence 170
 }
 
-public func >>> <V: ReversibleValueTransformerType, W: ReversibleValueTransformerType where V.TransformedValueType == W.ValueType, V.ErrorType == W.ErrorType>(lhs: V, rhs: W) -> ReversibleValueTransformer<V.ValueType, W.TransformedValueType, W.ErrorType> {
+public func >>> <V: ReversibleValueTransformerType, W: ReversibleValueTransformerType where V.TransformedValueType == W.ValueType, V.VTErrorType == W.VTErrorType>(lhs: V, rhs: W) -> ReversibleValueTransformer<V.ValueType, W.TransformedValueType, W.VTErrorType> {
     return compose(lhs, rhs)
 }
 
@@ -62,26 +62,26 @@ infix operator <<< {
     precedence 170
 }
 
-public func <<< <V: ReversibleValueTransformerType, W: ReversibleValueTransformerType where V.ValueType == W.TransformedValueType, V.ErrorType == W.ErrorType>(lhs: V, rhs: W) -> ReversibleValueTransformer<W.ValueType, V.TransformedValueType, V.ErrorType> {
+public func <<< <V: ReversibleValueTransformerType, W: ReversibleValueTransformerType where V.ValueType == W.TransformedValueType, V.VTErrorType == W.VTErrorType>(lhs: V, rhs: W) -> ReversibleValueTransformer<W.ValueType, V.TransformedValueType, V.VTErrorType> {
     return compose(rhs, lhs)
 }
 
 // MARK: - Lift (Optional)
 
-public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V, defaultReverseTransformedValue: V.ValueType) -> ReversibleValueTransformer<V.ValueType, V.TransformedValueType?, V.ErrorType> {
+public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V, defaultReverseTransformedValue: V.ValueType) -> ReversibleValueTransformer<V.ValueType, V.TransformedValueType?, V.VTErrorType> {
     return combine(lift(reversibleValueTransformer) as ValueTransformer, lift(flip(reversibleValueTransformer), defaultTransformedValue: defaultReverseTransformedValue) as ValueTransformer)
 }
 
-public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V, defaultTransformedValue: V.TransformedValueType) -> ReversibleValueTransformer<V.ValueType?, V.TransformedValueType, V.ErrorType> {
+public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V, defaultTransformedValue: V.TransformedValueType) -> ReversibleValueTransformer<V.ValueType?, V.TransformedValueType, V.VTErrorType> {
     return combine(lift(reversibleValueTransformer, defaultTransformedValue: defaultTransformedValue) as ValueTransformer, lift(flip(reversibleValueTransformer)) as ValueTransformer)
 }
 
-public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> ReversibleValueTransformer<V.ValueType?, V.TransformedValueType?, V.ErrorType> {
+public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> ReversibleValueTransformer<V.ValueType?, V.TransformedValueType?, V.VTErrorType> {
     return combine(lift(reversibleValueTransformer) as ValueTransformer, lift(flip(reversibleValueTransformer)) as ValueTransformer)
 }
 
 // MARK: - Lift (Array)
 
-public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> ReversibleValueTransformer<[V.ValueType], [V.TransformedValueType], V.ErrorType> {
+public func lift<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> ReversibleValueTransformer<[V.ValueType], [V.TransformedValueType], V.VTErrorType> {
     return combine(lift(reversibleValueTransformer) as ValueTransformer, lift(flip(reversibleValueTransformer)) as ValueTransformer)
 }

--- a/ValueTransformer/ReversibleValueTransformerType.swift
+++ b/ValueTransformer/ReversibleValueTransformerType.swift
@@ -3,17 +3,17 @@
 import Result
 
 public protocol ReversibleValueTransformerType: ValueTransformerType {
-    func reverseTransform(transformedValue: TransformedValueType) -> Result<ValueType, ErrorType>
+    func reverseTransform(transformedValue: TransformedValueType) -> Result<ValueType, VTErrorType>
 }
 
 // MARK: - Basics
 
 @available(*, introduced=1.0, deprecated=2.1, message="Use valueTransformer.reverseTransform(transformedValue).")
-public func reverseTransform<V: ReversibleValueTransformerType>(reversibleValueTransformer: V, transformedValue: V.TransformedValueType) -> Result<V.ValueType, V.ErrorType> {
+public func reverseTransform<V: ReversibleValueTransformerType>(reversibleValueTransformer: V, transformedValue: V.TransformedValueType) -> Result<V.ValueType, V.VTErrorType> {
     return reversibleValueTransformer.reverseTransform(transformedValue)
 }
 
-public func reverseTransform<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> V.TransformedValueType -> Result<V.ValueType, V.ErrorType> {
+public func reverseTransform<V: ReversibleValueTransformerType>(reversibleValueTransformer: V) -> V.TransformedValueType -> Result<V.ValueType, V.VTErrorType> {
     return { transformedValue in
         return reversibleValueTransformer.reverseTransform(transformedValue)
     }

--- a/ValueTransformer/ValueTransformer.swift
+++ b/ValueTransformer/ValueTransformer.swift
@@ -2,7 +2,7 @@
 
 import Result
 
-public struct ValueTransformer<Value, TransformedValue, Error>: ValueTransformerType {
+public struct ValueTransformer<Value, TransformedValue, Error: ErrorType>: ValueTransformerType {
     private let transformClosure: Value -> Result<TransformedValue, Error>
 
     public init(transformClosure: Value -> Result<TransformedValue, Error>) {
@@ -15,7 +15,7 @@ public struct ValueTransformer<Value, TransformedValue, Error>: ValueTransformer
 }
 
 extension ValueTransformer {
-    public init<V: ValueTransformerType where V.ValueType == Value, V.TransformedValueType == TransformedValue, V.ErrorType == Error>(_ valueTransformer: V) {
+    public init<V: ValueTransformerType where V.ValueType == Value, V.TransformedValueType == TransformedValue, V.VTErrorType == Error>(_ valueTransformer: V) {
         self.init(transformClosure: { value in
             return valueTransformer.transform(value)
         })
@@ -24,7 +24,7 @@ extension ValueTransformer {
 
 // MARK: - Compose
 
-public func compose<V: ValueTransformerType, W: ValueTransformerType where V.TransformedValueType == W.ValueType, V.ErrorType == W.ErrorType>(left: V, _ right: W) -> ValueTransformer<V.ValueType, W.TransformedValueType, W.ErrorType> {
+public func compose<V: ValueTransformerType, W: ValueTransformerType where V.TransformedValueType == W.ValueType, V.VTErrorType == W.VTErrorType>(left: V, _ right: W) -> ValueTransformer<V.ValueType, W.TransformedValueType, W.VTErrorType> {
     return ValueTransformer { value in
         return left.transform(value).flatMap(transform(right))
     }
@@ -35,7 +35,7 @@ infix operator >>> {
     precedence 170
 }
 
-public func >>> <V: ValueTransformerType, W: ValueTransformerType where V.TransformedValueType == W.ValueType, V.ErrorType == W.ErrorType>(lhs: V, rhs: W) -> ValueTransformer<V.ValueType, W.TransformedValueType, W.ErrorType> {
+public func >>> <V: ValueTransformerType, W: ValueTransformerType where V.TransformedValueType == W.ValueType, V.VTErrorType == W.VTErrorType>(lhs: V, rhs: W) -> ValueTransformer<V.ValueType, W.TransformedValueType, W.VTErrorType> {
     return compose(lhs, rhs)
 }
 
@@ -44,13 +44,13 @@ infix operator <<< {
     precedence 170
 }
 
-public func <<< <V: ValueTransformerType, W: ValueTransformerType where V.ValueType == W.TransformedValueType, V.ErrorType == W.ErrorType>(lhs: V, rhs: W) -> ValueTransformer<W.ValueType, V.TransformedValueType, V.ErrorType> {
+public func <<< <V: ValueTransformerType, W: ValueTransformerType where V.ValueType == W.TransformedValueType, V.VTErrorType == W.VTErrorType>(lhs: V, rhs: W) -> ValueTransformer<W.ValueType, V.TransformedValueType, V.VTErrorType> {
     return compose(rhs, lhs)
 }
 
 // MARK: - Lift (Optional)
 
-public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransformer<V.ValueType, V.TransformedValueType?, V.ErrorType> {
+public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransformer<V.ValueType, V.TransformedValueType?, V.VTErrorType> {
     return ValueTransformer { value in
         return valueTransformer.transform(value).map { value in
             return .Some(value)
@@ -58,21 +58,25 @@ public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransform
     }
 }
 
-public func lift<V: ValueTransformerType>(valueTransformer: V, defaultTransformedValue: V.TransformedValueType) -> ValueTransformer<V.ValueType?, V.TransformedValueType, V.ErrorType> {
-    return ValueTransformer { value in
-        return value.map(transform(valueTransformer)) ?? Result.success(defaultTransformedValue)
+public func lift<V: ValueTransformerType>(valueTransformer: V, defaultTransformedValue: V.TransformedValueType) -> ValueTransformer<V.ValueType?, V.TransformedValueType, V.VTErrorType> {
+    let closure: V.ValueType? -> Result<V.TransformedValueType, V.VTErrorType> = {
+        value in
+        return value.map(transform(valueTransformer)) ?? Result.Success(defaultTransformedValue)
     }
+
+    return ValueTransformer(transformClosure: closure)
 }
 
-public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransformer<V.ValueType?, V.TransformedValueType?, V.ErrorType> {
+public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransformer<V.ValueType?, V.TransformedValueType?, V.VTErrorType> {
     return lift(lift(valueTransformer), defaultTransformedValue: nil)
 }
 
 // MARK: - Lift (Array)
 
-public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransformer<[V.ValueType], [V.TransformedValueType], V.ErrorType> {
-    return ValueTransformer { values in
-        return values.reduce(Result.success([])) { (result, value) in
+public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransformer<[V.ValueType], [V.TransformedValueType], V.VTErrorType> {
+    let closure: [V.ValueType] -> Result<[V.TransformedValueType], V.VTErrorType> = {
+        values in
+        return values.reduce(Result.Success([])) { (result, value) in
             return result.flatMap { result in
                 return valueTransformer.transform(value).map { value in
                     return result + [ value ]
@@ -80,4 +84,6 @@ public func lift<V: ValueTransformerType>(valueTransformer: V) -> ValueTransform
             }
         }
     }
+
+    return ValueTransformer(transformClosure: closure)
 }

--- a/ValueTransformer/ValueTransformerType.swift
+++ b/ValueTransformer/ValueTransformerType.swift
@@ -5,19 +5,19 @@ import Result
 public protocol ValueTransformerType {
     typealias ValueType
     typealias TransformedValueType
-    typealias ErrorType
+    typealias VTErrorType: ErrorType
 
-    func transform(value: ValueType) -> Result<TransformedValueType, ErrorType>
+    func transform(value: ValueType) -> Result<TransformedValueType, VTErrorType>
 }
 
 // MARK: - Basics
 
 @available(*, introduced=1.0, deprecated=2.1, message="Use valueTransformer.transform(value).")
-public func transform<V: ValueTransformerType>(valueTransformer: V, value: V.ValueType) -> Result<V.TransformedValueType, V.ErrorType> {
+public func transform<V: ValueTransformerType>(valueTransformer: V, value: V.ValueType) -> Result<V.TransformedValueType, V.VTErrorType> {
     return valueTransformer.transform(value)
 }
 
-public func transform<V: ValueTransformerType>(valueTransformer: V) -> V.ValueType -> Result<V.TransformedValueType, V.ErrorType> {
+public func transform<V: ValueTransformerType>(valueTransformer: V) -> V.ValueType -> Result<V.TransformedValueType, V.VTErrorType> {
     return { value in
         valueTransformer.transform(value)
     }

--- a/ValueTransformerTests/ValueTransformerSpecs.swift
+++ b/ValueTransformerTests/ValueTransformerSpecs.swift
@@ -9,14 +9,14 @@ import ValueTransformer
 struct ValueTransformers {
     static let string = ValueTransformer<String, Int, NSError> { value in
         if let value = Int(value) {
-            return Result.success(value)
+            return Result.Success(value)
         } else {
-            return Result.failure(NSError(domain: "ValueTransformer", code: 0, userInfo: nil))
+            return Result.Failure(NSError(domain: "ValueTransformer", code: 0, userInfo: nil))
         }
     }
 
     static let int = ValueTransformer<Int, String, NSError> { value in
-        return Result.success(String(value))
+        return Result.Success(String(value))
     }
 }
 


### PR DESCRIPTION
Hi, I've made some changes, the most notable one is refactoring

```
typealias ErrorType
```

to

```
typealias VTErrorType: ErrorType
```

I think it's required because `ErrorType` is the protocol defined in the swift standard library, please let me know if I've made mistakes (PS: newbie in swift and iOS development). The tests passed.
